### PR TITLE
Version 2.2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,6 @@ build:
 # Tests
 test_suite:
 	forge test --use 0.8.17
+	forge test --use 0.8.18
 	forge test --use 0.8.19
 	forge test --use 0.8.20

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,7 @@ build:
 	forge fmt && forge clean && forge build --optimize --optimizer-runs 2000
 
 # Tests
-tests:
-	forge test --gas-report -vvv
+test_suite:
+	forge test --use 0.8.17
+	forge test --use 0.8.19
+	forge test --use 0.8.20

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ When cloning, you must use either `make remove && make install` or `make update`
 
 We use OpenZeppelin contracts version 4.8.3 in this codebase.
 
+## Testing
+You should run the test suite with `make test_suite`. 
+
+This loops through the following solidity versions:
+- 0.8.17
+- 0.8.18
+- 0.8.19
+- 0.8.20
+
 ## Disclaimer
 This codebase is provided on an "as is" and "as available" basis.
 

--- a/src/access/OwnableAccessControl.sol
+++ b/src/access/OwnableAccessControl.sol
@@ -24,7 +24,7 @@ error NotRoleOrOwner(bytes32 role);
 /// @dev by default, only the owner can grant roles but by inheriting, but you
 ///      may allow other roles to grant roles by using the internal helper.
 /// @author transientlabs.xyz
-/// @custom:version 2.2.0
+/// @custom:version 2.2.2
 abstract contract OwnableAccessControl is Ownable {
     /*//////////////////////////////////////////////////////////////////////////
                                 State Variables

--- a/src/access/OwnableAccessControl.sol
+++ b/src/access/OwnableAccessControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {EnumerableSet} from "openzeppelin/utils/structs/EnumerableSet.sol";
 import {Ownable} from "openzeppelin/access/Ownable.sol";

--- a/src/royalties/EIP2981TL.sol
+++ b/src/royalties/EIP2981TL.sol
@@ -24,7 +24,7 @@ error MaxRoyaltyError();
 /// @dev follows EIP-2981 (https://eips.ethereum.org/EIPS/eip-2981)
 /// @author transientlabs.xyz
 /// https://github.com/Transient-Labs/tl-sol-tools
-/// @custom:version 2.2.0
+/// @custom:version 2.2.2
 abstract contract EIP2981TL is IEIP2981, ERC165 {
     /*//////////////////////////////////////////////////////////////////////////
                                 Royalty Struct

--- a/src/royalties/EIP2981TL.sol
+++ b/src/royalties/EIP2981TL.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {ERC165} from "openzeppelin/utils/introspection/ERC165.sol";
 import {IEIP2981} from "./IEIP2981.sol";

--- a/src/royalties/IEIP2981.sol
+++ b/src/royalties/IEIP2981.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 ///
 /// @dev Interface for the NFT Royalty Standard

--- a/src/upgradeable/access/OwnableAccessControlUpgradeable.sol
+++ b/src/upgradeable/access/OwnableAccessControlUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {Initializable} from "openzeppelin-upgradeable/proxy/utils/Initializable.sol";
 import {EnumerableSetUpgradeable} from "openzeppelin-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";

--- a/src/upgradeable/access/OwnableAccessControlUpgradeable.sol
+++ b/src/upgradeable/access/OwnableAccessControlUpgradeable.sol
@@ -25,7 +25,7 @@ error NotRoleOrOwner(bytes32 role);
 /// @dev by default, only the owner can grant roles but by inheriting, but you
 ///      may allow other roles to grant roles by using the internal helper.
 /// @author transientlabs.xyz
-/// @custom:version 2.2.0
+/// @custom:version 2.2.2
 abstract contract OwnableAccessControlUpgradeable is Initializable, OwnableUpgradeable {
     /*//////////////////////////////////////////////////////////////////////////
                                 State Variables

--- a/src/upgradeable/royalties/EIP2981TLUpgradeable.sol
+++ b/src/upgradeable/royalties/EIP2981TLUpgradeable.sol
@@ -24,7 +24,7 @@ error MaxRoyaltyError();
 ///         while allowing for specific token overrides
 /// @dev follows EIP-2981 (https://eips.ethereum.org/EIPS/eip-2981)
 /// @author transientlabs.xyz
-/// @custom:version 2.2.0
+/// @custom:version 2.2.2
 abstract contract EIP2981TLUpgradeable is IEIP2981, Initializable, ERC165Upgradeable {
     /*//////////////////////////////////////////////////////////////////////////
                                 Royalty Struct

--- a/src/upgradeable/royalties/EIP2981TLUpgradeable.sol
+++ b/src/upgradeable/royalties/EIP2981TLUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {Initializable} from "openzeppelin-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165Upgradeable} from "openzeppelin-upgradeable/utils/introspection/ERC165Upgradeable.sol";

--- a/test/EIP2981TL.t.sol
+++ b/test/EIP2981TL.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
 import {MockEIP2981TL} from "./mocks/MockEIP2981TL.sol";

--- a/test/OwnableAccessControl.t.sol
+++ b/test/OwnableAccessControl.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
 import {MockOwnableAccessControl} from "./mocks/MockOwnableAccessControl.sol";

--- a/test/mocks/MockEIP2981TL.sol
+++ b/test/mocks/MockEIP2981TL.sol
@@ -2,7 +2,7 @@
 
 /// @dev this contract does not have proper access control but is only for testing
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {EIP2981TL} from "../../src/royalties/EIP2981TL.sol";
 

--- a/test/mocks/MockOwnableAccessControl.sol
+++ b/test/mocks/MockOwnableAccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {OwnableAccessControl} from "../../src/access/OwnableAccessControl.sol";
 

--- a/test/upgradeable/EIP2981TLUpgradeable.t.sol
+++ b/test/upgradeable/EIP2981TLUpgradeable.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
 import {MockEIP2981TLUpgradeable} from "./mocks/MockEIP2981TLUpgradeable.sol";

--- a/test/upgradeable/OwnableAccessControlUpgradeable.t.sol
+++ b/test/upgradeable/OwnableAccessControlUpgradeable.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
 import {MockOwnableAccessControlUpgradeable} from "./mocks/MockOwnableAccessControlUpgradeable.sol";

--- a/test/upgradeable/mocks/MockEIP2981TLUpgradeable.sol
+++ b/test/upgradeable/mocks/MockEIP2981TLUpgradeable.sol
@@ -2,7 +2,7 @@
 
 /// @dev this contract does not have proper access control but is only for testing
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {Initializable} from "openzeppelin-upgradeable/proxy/utils/Initializable.sol";
 import {EIP2981TLUpgradeable} from "../../../src/upgradeable/royalties/EIP2981TLUpgradeable.sol";

--- a/test/upgradeable/mocks/MockOwnableAccessControlUpgradeable.sol
+++ b/test/upgradeable/mocks/MockOwnableAccessControlUpgradeable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.17;
 
 import {Initializable} from "openzeppelin-upgradeable/proxy/utils/Initializable.sol";
 import {OwnableAccessControlUpgradeable} from "../../../src/upgradeable/access/OwnableAccessControlUpgradeable.sol";


### PR DESCRIPTION
Changed to a solidity floating pragma and tested with 0.8.17, 0.8.18, 0.8.19, and 0.8.20. All tests passing.