### PR TITLE
Griefing fix - v2.6.0

### DIFF
--- a/src/payments/TransferHelper.sol
+++ b/src/payments/TransferHelper.sol
@@ -21,7 +21,7 @@ error InsufficentERC20Transfer();
 /// @title Transfer Helper
 /// @notice Abstract contract that has helper function for sending ETH and ERC20's safely
 /// @author transientlabs.xyz
-/// @custom:last-updated 2.3.0
+/// @custom:last-updated 2.6.0
 abstract contract TransferHelper {
     /*//////////////////////////////////////////////////////////////////////////
                                   State Variables
@@ -34,14 +34,25 @@ abstract contract TransferHelper {
                                    ETH Functions
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Function to force transfer ETH
+    /// @notice Function to force transfer ETH, defaulting to forwarding 100k gas
     /// @dev On failure to send the ETH, the ETH is converted to WETH and sent
     /// @dev Care should be taken to always pass the proper WETH address that adheres to IWETH
     /// @param recipient The recipient of the ETH
     /// @param amount The amount of ETH to send
     /// @param weth The WETH token address
     function _safeTransferETH(address recipient, uint256 amount, address weth) internal {
-        (bool success,) = recipient.call{value: amount}("");
+        _safeTransferETH(recipient, amount, weth, 1e5);
+    }
+
+    /// @notice Function to force transfer ETH, with a gas limit
+    /// @dev On failure to send the ETH, the ETH is converted to WETH and sent
+    /// @dev Care should be taken to always pass the proper WETH address that adheres to IWETH
+    /// @param recipient The recipient of the ETH
+    /// @param amount The amount of ETH to send
+    /// @param weth The WETH token address
+    /// @param gasLimit The gas to forward
+    function _safeTransferETH(address recipient, uint256 amount, address weth, uint256 gasLimit) internal {
+        (bool success,) = recipient.call{value: amount, gas: gasLimit}("");
         if (!success) {
             IWETH token = IWETH(weth);
             token.deposit{value: amount}();

--- a/test/payments/TransferHelper.t.sol
+++ b/test/payments/TransferHelper.t.sol
@@ -56,6 +56,8 @@ contract TestTransferHelper is Test {
             recipient.code.length == 0 && recipient > address(100)
         );
 
+        vm.assume(amount < 1_000_000_000_000_000_000 ether);
+
         // test contract receiver
         vm.deal(address(th), amount);
         uint256 b1 = receiver.balance;
@@ -73,6 +75,12 @@ contract TestTransferHelper is Test {
         uint256 b3 = IERC20(weth).balanceOf(revertingReceiver);
         th.safeTransferETH(revertingReceiver, amount, weth);
         assert(IERC20(weth).balanceOf(revertingReceiver) - b3 == amount);
+
+        // test griefing receiver
+        vm.deal(address(th), amount);
+        uint256 b4 = IERC20(weth).balanceOf(griefingReceiver);
+        th.safeTransferETH(griefingReceiver, amount, weth);
+        assert(IERC20(weth).balanceOf(griefingReceiver) - b4 == amount);
     }
 
     function testSafeTransferETHWithGasLimit(address recipient, uint256 amount) public {

--- a/test/utils/Receivers.sol
+++ b/test/utils/Receivers.sol
@@ -14,3 +14,12 @@ contract RevertingReceiver {
         revert("you shall not pass");
     }
 }
+
+contract GriefingReceiver {
+    event Grief();
+    receive() external payable {
+        for (uint256 i = 0; i < type(uint256).max; i++) {
+            emit Grief();
+        }
+    }
+}


### PR DESCRIPTION
Update to the `TransferHelper.sol` to avoid gas griefing attacks when sending ETH to an address.